### PR TITLE
chore: remove code for unsupported OS versions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -263,7 +263,9 @@ class pam_pkcs11 (
     'none'                                                          # lint:ignore:trailing_comma
   ]                            $pam_config             = $pam_pkcs11::params::pam_config,
 ) inherits pam_pkcs11::params {
-  if $ca_dir_source != [] and $facts['os']['family'] == 'RedHat' { fail('The `ca_dir_source` parameter is not supported on RedHat OS families.') }
+  if $ca_dir_source != [] and $facts['os']['family'] == 'RedHat' {
+    fail('The `ca_dir_source` parameter is not supported on RedHat OS families.')
+  }
 
   $merged_pkcs11_module  = merge($pkcs11_module_base, $pkcs11_module)
   $merged_mapper_options = deep_merge($mapper_options_base, $mapper_options)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class pam_pkcs11::params {
       # Debian 11 uses version 0.6.11
       # Ubuntu 18.04 uses version 0.6.9
       # Ubuntu 20.04 uses version 0.6.11
+      # Ubuntu 22.04 uses version 0.6.11
       $package_name = 'libpam-pkcs11'
       $ca_dir       = '/etc/pam_pkcs11/cacerts'
       $nss_dir      = undef


### PR DESCRIPTION
This PR simplifies the code in `params.pp` by only taking into account the supported OS versions.

It also makes the module usable on Ubuntu 22.04, even though it's not officially supported or tested. 

Related to #6