### PR TITLE
chore: disable Puppet 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,11 +343,10 @@ following operating systems:
 ### Puppet stack compatibility
 
 This module is tested with the following software. For complete details see
-the GitHub actions configuration.
+[`metadata.json`](metadata.json) and the [GitHub actions configuration](.github/workflows/).
 
 * Puppet
-    * 6.27
-    * 7.17
+    * 7
 * Ruby
     * 2.5
     * 2.6

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.6.1",


### PR DESCRIPTION
Puppet 6 has reached EOL in February 2023, see
https://groups.google.com/g/puppet-announce/c/mbccWrN0tX8 and https://www.puppet.com/docs/puppet/7/release_notes_osp.html.